### PR TITLE
Enable the Maintenance mode for the Friendica backup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Friendica is a decentralised communications platform that integrates social comm
 
 Friendica connects you effortlessly to a federated communications network of several thousand servers, with more than half a million user registrations. You can directly connect to anyone on Friendica, Mastodon, Diaspora, GnuSocial, Pleroma, or Hubzilla, regardless where each user profile is hosted.
 
-**Shipped version:** 2022.12~ynh1
+**Shipped version:** 2023.01~ynh1
 
 **Demo:** https://dir.friendica.social/servers
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,15 +5,15 @@ It shall NOT be edited by hand.
 
 # Friendica pour YunoHost
 
-[![Niveau d'intégration](https://dash.yunohost.org/integration/friendica.svg)](https://dash.yunohost.org/appci/app/friendica) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/friendica.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/friendica.maintain.svg)  
+[![Niveau d’intégration](https://dash.yunohost.org/integration/friendica.svg)](https://dash.yunohost.org/appci/app/friendica) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/friendica.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/friendica.maintain.svg)  
 [![Installer Friendica avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=friendica)
 
 *[Read this readme in english.](./README.md)*
 
-> *Ce package vous permet d'installer Friendica rapidement et simplement sur un serveur YunoHost.
-Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour savoir comment l'installer et en profiter.*
+> *Ce package vous permet d’installer Friendica rapidement et simplement sur un serveur YunoHost.
+Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour savoir comment l’installer et en profiter.*
 
-## Vue d'ensemble
+## Vue d’ensemble
 
 Friendica is a decentralised communications platform that integrates social communication. The platform links to independent social projects and corporate services.
 
@@ -23,9 +23,9 @@ Friendica connects you effortlessly to a federated communications network of sev
 
 **Démo :** https://dir.friendica.social/servers
 
-## Captures d'écran
+## Captures d’écran
 
-![Capture d'écran de Friendica](./doc/screenshots/friendica-vier-profile.png)
+![Capture d’écran de Friendica](./doc/screenshots/friendica-vier-profile.png)
 
 ## Avertissements / informations importantes
 
@@ -51,10 +51,10 @@ https://github.com/YunoHost-Apps/friendica_ynh
 
 ## Documentations et ressources
 
-* Site officiel de l'app : <http://friendi.ca>
+* Site officiel de l’app : <http://friendi.ca>
 * Documentation officielle utilisateur : <https://wiki.friendi.ca/>
-* Documentation officielle de l'admin : <https://github.com/friendica/friendica/wiki>
-* Dépôt de code officiel de l'app : <https://github.com/friendica/friendica>
+* Documentation officielle de l’admin : <https://github.com/friendica/friendica/wiki>
+* Dépôt de code officiel de l’app : <https://github.com/friendica/friendica>
 * Documentation YunoHost pour cette app : <https://yunohost.org/app_friendica>
 * Signaler un bug : <https://github.com/YunoHost-Apps/friendica_ynh/issues>
 
@@ -70,4 +70,4 @@ ou
 sudo yunohost app upgrade friendica -u https://github.com/YunoHost-Apps/friendica_ynh/tree/testing --debug
 ```
 
-**Plus d'infos sur le packaging d'applications :** <https://yunohost.org/packaging_apps>
+**Plus d’infos sur le packaging d’applications :** <https://yunohost.org/packaging_apps>

--- a/README_fr.md
+++ b/README_fr.md
@@ -19,7 +19,7 @@ Friendica is a decentralised communications platform that integrates social comm
 
 Friendica connects you effortlessly to a federated communications network of several thousand servers, with more than half a million user registrations. You can directly connect to anyone on Friendica, Mastodon, Diaspora, GnuSocial, Pleroma, or Hubzilla, regardless where each user profile is hosted.
 
-**Version incluse :** 2022.12~ynh1
+**Version incluse :** 2023.01~ynh1
 
 **Démo :** https://dir.friendica.social/servers
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Social Communication Server",
         "fr": "Serveur de Communication Social"
     },
-    "version": "2022.12~ynh1",
+    "version": "2023.01~ynh1",
     "url": "http://friendi.ca",
     "upstream": {
         "license": "AGPL-3.0-only",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,7 +6,7 @@
 
 # commit hashes
 # 2022.12
-version_commit="8b3a9fc58a969a3d9202f6858d5228f3a28be1ef"
+version_commit="eeadc00e83d8bc7144b0edf74c0fe851ef8636a6"
 addons_version_commit="f922d69310f5229d2e9404f396d66453b2d19d90"
 
 # dependencies used by the app

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -6,7 +6,7 @@
 
 # commit hashes
 # 2022.12
-version_commit="eeadc00e83d8bc7144b0edf74c0fe851ef8636a6"
+version_commit="9d7e172d2c106eee94b3fddfa42cc023532228d3"
 addons_version_commit="f922d69310f5229d2e9404f396d66453b2d19d90"
 
 # dependencies used by the app

--- a/scripts/backup
+++ b/scripts/backup
@@ -63,6 +63,10 @@ ynh_backup --src_path="/etc/php/$phpversion/fpm/pool.d/$app.conf"
 # Backup cron job
 ynh_backup --src_path="/etc/cron.d/$app"
 
+# Put Friendica in maintenance mode
+ynh_print_info --message="Enabling the maintenance mode for Friendica"
+/var/www/friendica/bin/console maintenance 1
+
 #=================================================
 # BACKUP THE MYSQL DATABASE
 #=================================================
@@ -70,8 +74,13 @@ ynh_print_info --message="Backing up the MySQL database..."
 
 ynh_mysql_dump_db --database="$db_name" > db.sql
 
+# Disable the maintenance mode for Friendica
+ynh_print_info --message="Disabling the maintenance mode for Friendica"
+/var/www/friendica/bin/console maintenance 0
+
 #=================================================
 # END OF SCRIPT
 #=================================================
+
 
 ynh_print_info --message="Backup script completed for $app. (YunoHost will then actually copy those files to the archive)."


### PR DESCRIPTION
This is done to avoid errors with the database and be able to properly back it up. Else it will fail if you Friendica is an active instance and in the time that it takes to create a backup new entries will be added to the database. I tested it it works.